### PR TITLE
Make `TrustDnsResolver` generic allowing it to be generic across Runtime Providers, and add a new `TokioTrustDnsResolver` replicating previous behaviour.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ repository = "https://github.com/Gelbpunkt/hyper-trust-dns"
 
 [dependencies]
 hyper = { version = "0.14", default-features = false, features = ["client", "runtime", "tcp"] }
-tokio = { version = "1", default-features = false, features = ["rt"] }
-trust-dns-resolver = { version = "0.23.0-alpha.2", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.23.0-alpha.2", default-features = false }
+
+# Tokio
+tokio = { version = "1", default-features = false, optional = true, features = ["rt"] }
 
 # Rustls
-hyper-rustls = { version = "0.23", default-features = false, features = ["tokio-runtime"], optional = true }
+hyper-rustls = { version = "0.23", default-features = false, optional = true }
 
 # Native-TLS
 hyper-tls = { version = "0.5", default-features = false, optional = true }
@@ -26,8 +28,11 @@ hyper-rustls = { version = "0.23", default-features = false, features = ["tokio-
 tokio = { version = "1", default-features = false, features = ["rt", "macros"] }
 
 [features]
-default = ["https-only", "rustls-webpki", "rustls-http1"]
+default = ["https-only", "rustls-webpki", "rustls-http1", "tokio"]
 https-only = []
+
+# Tokio feature
+tokio = ["dep:tokio", "trust-dns-resolver/tokio-runtime", "hyper-rustls?/tokio-runtime"]
 
 # Configuration features
 system-config = ["trust-dns-resolver/system-config"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ homepage = "https://github.com/Gelbpunkt/hyper-trust-dns"
 repository = "https://github.com/Gelbpunkt/hyper-trust-dns"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[patch.crates-io]
+trust-dns-resolver = { git = "https://github.com/XOR-op/trust-dns", branch = "main" }
 
 [dependencies]
 hyper = { version = "0.14", default-features = false, features = ["client", "runtime", "tcp"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/Gelbpunkt/hyper-trust-dns"
 
 [dependencies]
 hyper = { version = "0.14", default-features = false, features = ["client", "runtime", "tcp"] }
-trust-dns-resolver = { version = "0.23.0-alpha.2", default-features = false }
+trust-dns-resolver = { version = "0.23.0-alpha.5", default-features = false }
 
 # Rustls
 hyper-rustls = { version = "0.24", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ repository = "https://github.com/Gelbpunkt/hyper-trust-dns"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [patch.crates-io]
-trust-dns-resolver = { git = "https://github.com/XOR-op/trust-dns", branch = "main" }
+trust-dns-resolver = { git = "https://git@github.com/bluejekyll/trust-dns", tag = "v0.23.0-alpha.1" }
 
 [dependencies]
 hyper = { version = "0.14", default-features = false, features = ["client", "runtime", "tcp"] }
 tokio = { version = "1", default-features = false, features = ["rt"] }
-trust-dns-resolver = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "=0.23.0-alpha.1", default-features = false, features = ["tokio-runtime"] }
 
 # Rustls
 hyper-rustls = { version = "0.23", default-features = false, features = ["tokio-runtime"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/Gelbpunkt/hyper-trust-dns"
 
 [dependencies]
 hyper = { version = "0.14", default-features = false, features = ["client", "runtime", "tcp"] }
-trust-dns-resolver = { version = "0.23.0-alpha.5", default-features = false }
+trust-dns-resolver = { version = "0.23.0", default-features = false }
 
 # Rustls
 hyper-rustls = { version = "0.24", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ hyper = { version = "0.14", default-features = false, features = ["client", "run
 trust-dns-resolver = { version = "0.23.0-alpha.2", default-features = false }
 
 # Tokio
-tokio = { version = "1", default-features = false, optional = true, features = ["rt"] }
+tokio = { version = "1.17", default-features = false, optional = true, features = ["rt"] }
 
 # Rustls
 hyper-rustls = { version = "0.24", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,6 @@ repository = "https://github.com/Gelbpunkt/hyper-trust-dns"
 hyper = { version = "0.14", default-features = false, features = ["client", "runtime", "tcp"] }
 trust-dns-resolver = { version = "0.23.0-alpha.2", default-features = false }
 
-# Tokio
-tokio = { version = "1.17", default-features = false, optional = true, features = ["rt"] }
-
 # Rustls
 hyper-rustls = { version = "0.24", default-features = false, optional = true }
 
@@ -32,7 +29,7 @@ default = ["https-only", "rustls-webpki", "rustls-http1", "tokio"]
 https-only = []
 
 # Tokio feature
-tokio = ["dep:tokio", "trust-dns-resolver/tokio-runtime", "hyper-rustls?/tokio-runtime"]
+tokio = ["trust-dns-resolver/tokio-runtime", "hyper-rustls?/tokio-runtime"]
 
 # Configuration features
 system-config = ["trust-dns-resolver/system-config"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,10 @@ documentation = "https://docs.rs/hyper-trust-dns"
 homepage = "https://github.com/Gelbpunkt/hyper-trust-dns"
 repository = "https://github.com/Gelbpunkt/hyper-trust-dns"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[patch.crates-io]
-trust-dns-resolver = { git = "https://git@github.com/bluejekyll/trust-dns", tag = "v0.23.0-alpha.1" }
-
 [dependencies]
 hyper = { version = "0.14", default-features = false, features = ["client", "runtime", "tcp"] }
 tokio = { version = "1", default-features = false, features = ["rt"] }
-trust-dns-resolver = { version = "=0.23.0-alpha.1", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.23.0-alpha.2", default-features = false, features = ["tokio-runtime"] }
 
 # Rustls
 hyper-rustls = { version = "0.23", default-features = false, features = ["tokio-runtime"], optional = true }

--- a/README.md
+++ b/README.md
@@ -12,13 +12,20 @@ let connector = TrustDnsResolver::default().into_rustls_native_https_connector()
 let client: Client<_> = Client::builder().build(connector);
 ```
 
+## Resolvers
+
+There is a [`GenericTrustDnsResolver`] resolver which can be built from an [`AsyncResolver`] using [`GenericTrustDnsResolver::from_async_resolver`].
+
+For most cases where you are happy to use the standard [`TokioRuntimeProvider`] the [`TrustDnsResolver`] should be used and is able to be built much more easily.
+
+
 ## Types of connectors
 
 There are 3 connectors:
 
-- [`TrustDnsHttpConnector`], a wrapper around [`HttpConnector<TrustDnsResolver>`]. Created with [`TrustDnsResolver::into_http_connector`].
-- [`RustlsHttpsConnector`], a [hyper-rustls](https://github.com/rustls/hyper-rustls) based connector to work with [`TrustDnsHttpConnector`]. Created with [`TrustDnsResolver::into_rustls_native_https_connector`] or [`TrustDnsResolver::into_rustls_webpki_https_connector`].
-- [`NativeTlsHttpsConnector`], a [hyper-tls](https://github.com/hyperium/hyper-tls) based connector to work with [`TrustDnsHttpConnector`]. Created with [`TrustDnsResolver::into_native_tls_https_connector`].
+- [`TrustDnsHttpConnector`], a wrapper around [`HttpConnector<GenericTrustDnsResolver>`]. Created with [`GenericTrustDnsResolver::into_http_connector`].
+- [`RustlsHttpsConnector`], a [hyper-rustls](https://github.com/rustls/hyper-rustls) based connector to work with [`TrustDnsHttpConnector`]. Created with [`GenericTrustDnsResolver::into_rustls_native_https_connector`] or [`GenericTrustDnsResolver::into_rustls_webpki_https_connector`].
+- [`NativeTlsHttpsConnector`], a [hyper-tls](https://github.com/hyperium/hyper-tls) based connector to work with [`TrustDnsHttpConnector`]. Created with [`GenericTrustDnsResolver::into_native_tls_https_connector`].
 
 The HTTP connector is always available, the other two can be enabled via the `rustls-webpki` (uses webpki roots)/`rustls-native` (uses OS cert store) and `native-tls` features respectably.
 

--- a/README.md
+++ b/README.md
@@ -14,20 +14,24 @@ let client: Client<_> = Client::builder().build(connector);
 
 ## Resolvers
 
-There is a [`GenericTrustDnsResolver`] resolver which can be built from an [`AsyncResolver`] using [`GenericTrustDnsResolver::from_async_resolver`].
+There is a [`TrustDnsResolver`] resolver which can be built from an [`AsyncResolver`] using [`TrustDnsResolver::from_async_resolver`].
 
-For most cases where you are happy to use the standard [`TokioRuntimeProvider`] the [`TrustDnsResolver`] should be used and is able to be built much more easily.
+For most cases where you are happy to use the standard [`TokioRuntimeProvider`] the [`TokioTrustDnsResolver`] should be used and is able to be built much more easily
+(but requires the `tokio` feature to be enabled, which it is by default).
 
 
 ## Types of connectors
 
-There are 3 connectors:
+There are 6 connectors:
 
-- [`TrustDnsHttpConnector`], a wrapper around [`HttpConnector<GenericTrustDnsResolver>`]. Created with [`GenericTrustDnsResolver::into_http_connector`].
-- [`RustlsHttpsConnector`], a [hyper-rustls](https://github.com/rustls/hyper-rustls) based connector to work with [`TrustDnsHttpConnector`]. Created with [`GenericTrustDnsResolver::into_rustls_native_https_connector`] or [`GenericTrustDnsResolver::into_rustls_webpki_https_connector`].
-- [`NativeTlsHttpsConnector`], a [hyper-tls](https://github.com/hyperium/hyper-tls) based connector to work with [`TrustDnsHttpConnector`]. Created with [`GenericTrustDnsResolver::into_native_tls_https_connector`].
+- [`TrustDnsHttpConnector`], a wrapper around [`HttpConnector<TrustDnsResolver>`]. Created with [`TrustDnsResolver::into_http_connector`].
+- [`RustlsHttpsConnector`], a [hyper-rustls](https://github.com/rustls/hyper-rustls) based connector to work with [`TrustDnsHttpConnector`]. Created with [`TrustDnsResolver::into_rustls_native_https_connector`] or [`TrustDnsResolver::into_rustls_webpki_https_connector`].
+- [`NativeTlsHttpsConnector`], a [hyper-tls](https://github.com/hyperium/hyper-tls) based connector to work with [`TrustDnsHttpConnector`]. Created with [`TrustDnsResolver::into_native_tls_https_connector`].
+- [`TokioTrustDnsHttpConnector`], a wrapper around [`TrustDnsHttpConnector<TokioRuntimeProvider>`].
+- [`TokioNativeTlsHttpsConnector`], a wrapper around [`NativeTlsHttpsConnector<TokioRuntimeProvider>`]
+- [`TokioRustlsHttpsConnector`], a wrapper around [`RustlsHttpsConnector<TokioRuntimeProvider>`]
 
-The HTTP connector is always available, the other two can be enabled via the `rustls-webpki` (uses webpki roots)/`rustls-native` (uses OS cert store) and `native-tls` features respectably.
+The HTTP connector is always available, the other two non-tokio ones can be enabled via the `rustls-webpki` (uses webpki roots)/`rustls-native` (uses OS cert store) and `native-tls` features respectably. The `Tokio` prefixed variants also require the `tokio` feature to be enabled (which it is by default).
 
 ## Trust-DNS options
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This crate provides HTTP/HTTPS connectors for [hyper](https://github.com/hyperiu
 use hyper::Client;
 use hyper_trust_dns::TrustDnsResolver;
 
-let connector = TrustDnsResolver::default().into_rustls_native_https_connector();
+let connector = TrustDnsResolver::default().into_rustls_webpki_https_connector();
 let client: Client<_> = Client::builder().build(connector);
 ```
 

--- a/benches/requests_per_sec.rs
+++ b/benches/requests_per_sec.rs
@@ -56,7 +56,7 @@ fn hyper_trust_dns(c: &mut Criterion) {
         .unwrap();
 
     let https_connector =
-        hyper_trust_dns::TrustDnsResolver::new().into_rustls_webpki_https_connector();
+        hyper_trust_dns::TokioTrustDnsResolver::new().into_rustls_webpki_https_connector();
     let client: Client<_> = Client::builder().build(https_connector);
 
     c.bench_with_input(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ use hyper::{
     service::Service,
 };
 use trust_dns_resolver::{
-    error::ResolveError, lookup_ip::LookupIpIntoIter, name_server::ConnectionProvider, AsyncResolver,
+    error::ResolveError, lookup_ip::LookupIpIntoIter, name_server::ConnectionProvider,
+    AsyncResolver,
 };
 
 #[cfg(feature = "tokio")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,5 +295,8 @@ pub type TokioTrustDnsHttpConnector = TrustDnsHttpConnector<TokioRuntimeProvider
 pub type TokioNativeTlsHttpsConnector = NativeTlsHttpsConnector<TokioRuntimeProvider>;
 
 /// A [`hyper_rustls::HttpsConnector`] that uses a [`TokioTrustDnsHttpConnector`].
-#[cfg(all(any(feature = "rustls-native", feature = "rustls-webpki"), feature = "tokio"))]
+#[cfg(all(
+    any(feature = "rustls-native", feature = "rustls-webpki"),
+    feature = "tokio"
+))]
 pub type TokioRustlsHttpsConnector = RustlsHttpsConnector<TokioRuntimeProvider>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,3 +285,15 @@ pub type NativeTlsHttpsConnector<R> = hyper_tls::HttpsConnector<TrustDnsHttpConn
 /// A [`hyper_rustls::HttpsConnector`] that uses a [`TrustDnsHttpConnector`].
 #[cfg(any(feature = "rustls-native", feature = "rustls-webpki"))]
 pub type RustlsHttpsConnector<R> = hyper_rustls::HttpsConnector<TrustDnsHttpConnector<R>>;
+
+/// A [`HttpConnector`] that uses the [`TokioTrustDnsResolver`].
+#[cfg(feature = "tokio")]
+pub type TokioTrustDnsHttpConnector = TrustDnsHttpConnector<TokioRuntimeProvider>;
+
+/// A [`hyper_tls::HttpsConnector`] that uses a [`TokioTrustDnsHttpConnector`].
+#[cfg(all(feature = "native-tls", feature = "tokio"))]
+pub type TokioNativeTlsHttpsConnector = NativeTlsHttpsConnector<TokioRuntimeProvider>;
+
+/// A [`hyper_rustls::HttpsConnector`] that uses a [`TokioTrustDnsHttpConnector`].
+#[cfg(all(any(feature = "rustls-native", feature = "rustls-webpki"), feature = "tokio"))]
+pub type TokioRustlsHttpsConnector = RustlsHttpsConnector<TokioRuntimeProvider>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,12 @@ impl<R: RuntimeProvider> GenericTrustDnsResolver<R> {
         Self { resolver }
     }
 
+    /// Create a new [`TrustDnsHttpConnector`] with this resolver.
+    #[must_use]
+    pub fn into_http_connector(self) -> TrustDnsHttpConnector<R> {
+        TrustDnsHttpConnector::new_with_resolver(self)
+    }
+
     /// Create a new [`NativeTlsHttpsConnector`].
     #[cfg(feature = "native-tls")]
     #[must_use]
@@ -238,12 +244,6 @@ impl<R: RuntimeProvider> GenericTrustDnsResolver<R> {
 
         builder.wrap_connector(http_connector)
     }
-
-    /// Create a new [`TrustDnsHttpConnector`] with this resolver.
-    #[must_use]
-    pub fn into_http_connector(self) -> TrustDnsHttpConnector<R> {
-        TrustDnsHttpConnector::new_with_resolver(self)
-    }
 }
 
 impl<R: RuntimeProvider> Service<Name> for GenericTrustDnsResolver<R> {
@@ -268,7 +268,7 @@ impl<R: RuntimeProvider> Service<Name> for GenericTrustDnsResolver<R> {
     }
 }
 
-/// A [`HttpConnector`] that uses the [`TrustDnsResolver`].
+/// A [`HttpConnector`] that uses the [`GenericTrustDnsResolver`].
 pub type TrustDnsHttpConnector<R> = HttpConnector<GenericTrustDnsResolver<R>>;
 
 /// A [`hyper_tls::HttpsConnector`] that uses a [`TrustDnsHttpConnector`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,14 @@ impl TrustDnsResolver {
         Self { resolver }
     }
 
+    /// TODO
+    #[must_use]
+    pub fn from_async_resolver(tokio_async_resolver: TokioAsyncResolver) -> Self {
+        let resolver = Arc::new(tokio_async_resolver);
+
+        Self { resolver }
+    }
+
     /// Create a new [`TrustDnsHttpConnector`] with this resolver.
     #[must_use]
     pub fn into_http_connector(self) -> TrustDnsHttpConnector {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ use trust_dns_resolver::{
 /// A hyper resolver using `trust-dns`'s [`TokioAsyncResolver`].
 pub type TrustDnsResolver = GenericTrustDnsResolver<TokioRuntimeProvider>;
 
-/// A hyper resolver using `trust-dns`'s [`AsyncResolver`] and any RuntimeProvider.
+/// A hyper resolver using `trust-dns`'s [`AsyncResolver`] and any implementor of [`RuntimeProvider`].
 #[derive(Clone)]
 pub struct GenericTrustDnsResolver<R: RuntimeProvider> {
     resolver: Arc<AsyncResolver<R>>,
@@ -164,7 +164,7 @@ impl Default for TrustDnsResolver {
 }
 
 impl<R: RuntimeProvider> GenericTrustDnsResolver<R> {
-    /// Create a GenericTrustDnsResolver from the given AsyncResolver
+    /// Create a [`GenericTrustDnsResolver`] from the given [`AsyncResolver`]
     #[must_use]
     pub fn from_async_resolver(async_resolver: AsyncResolver<R>) -> Self {
         let resolver = Arc::new(async_resolver);

--- a/tests/test_http.rs
+++ b/tests/test_http.rs
@@ -1,9 +1,9 @@
 use hyper::{Body, Client, Request};
-use hyper_trust_dns::TrustDnsResolver;
+use hyper_trust_dns::TokioTrustDnsResolver;
 
 #[tokio::test]
 async fn test_lookup_works() {
-    let connector = TrustDnsResolver::default().into_http_connector();
+    let connector = TokioTrustDnsResolver::default().into_http_connector();
     let client = Client::builder().build(connector);
 
     let request = Request::builder()

--- a/tests/test_native_tls.rs
+++ b/tests/test_native_tls.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_native_tls_works() {
-        let connector = TrustDnsResolver::default().into_native_tls_https_connector();
+        let connector = TokioTrustDnsResolver::default().into_native_tls_https_connector();
         let client = Client::builder().build(connector);
 
         let request = Request::builder()

--- a/tests/test_native_tls.rs
+++ b/tests/test_native_tls.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "native-tls")]
 mod tests {
     use hyper::{Body, Client, Request};
-    use hyper_trust_dns::TrustDnsResolver;
+    use hyper_trust_dns::TokioTrustDnsResolver;
 
     #[tokio::test]
     async fn test_native_tls_works() {

--- a/tests/test_rustls.rs
+++ b/tests/test_rustls.rs
@@ -1,11 +1,11 @@
 mod tests {
     use hyper::{Body, Client, Request};
-    use hyper_trust_dns::TrustDnsResolver;
+    use hyper_trust_dns::TokioTrustDnsResolver;
 
     #[cfg(feature = "rustls-webpki")]
     #[tokio::test]
     async fn test_rustls_webpki_roots_works() {
-        let connector = TrustDnsResolver::default().into_rustls_webpki_https_connector();
+        let connector = TokioTrustDnsResolver::default().into_rustls_webpki_https_connector();
         let client = Client::builder().build(connector);
 
         let request = Request::builder()
@@ -22,7 +22,7 @@ mod tests {
     #[cfg(feature = "rustls-native")]
     #[tokio::test]
     async fn test_rustls_native_roots_works() {
-        let connector = TrustDnsResolver::default().into_rustls_native_https_connector();
+        let connector = TokioTrustDnsResolver::default().into_rustls_native_https_connector();
         let client = Client::builder().build(connector);
 
         let request = Request::builder()
@@ -39,7 +39,8 @@ mod tests {
     #[cfg(all(feature = "system-config", feature = "rustls-native"))]
     #[tokio::test]
     async fn test_sytem_config_works() {
-        let connector = TrustDnsResolver::from_system_conf().into_rustls_native_https_connector();
+        let connector =
+            TokioTrustDnsResolver::from_system_conf().into_rustls_native_https_connector();
         let client = Client::builder().build(connector);
 
         let request = Request::builder()
@@ -56,7 +57,8 @@ mod tests {
     #[cfg(all(feature = "dns-over-rustls", feature = "rustls-native"))]
     #[tokio::test]
     async fn test_dns_over_rustls_works() {
-        let connector = TrustDnsResolver::cloudflare_tls().into_rustls_native_https_connector();
+        let connector =
+            TokioTrustDnsResolver::cloudflare_tls().into_rustls_native_https_connector();
         let client = Client::builder().build(connector);
 
         let request = Request::builder()
@@ -73,7 +75,8 @@ mod tests {
     #[cfg(all(feature = "dns-over-https-rustls", feature = "rustls-native"))]
     #[tokio::test]
     async fn test_dns_over_https_rustls_works() {
-        let connector = TrustDnsResolver::cloudflare_https().into_rustls_native_https_connector();
+        let connector =
+            TokioTrustDnsResolver::cloudflare_https().into_rustls_native_https_connector();
         let client = Client::builder().build(connector);
 
         let request = Request::builder()


### PR DESCRIPTION
This PR builds on https://github.com/bluejekyll/trust-dns/pull/1876 which adds a new `RuntimeProvider` trait. This PR adds the ability to use any `RuntimeProvider` rather than just the Tokio one.

Obviously it can't be merged until that is done.